### PR TITLE
Create publish-to-npm.yaml

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -1,0 +1,21 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the publishing of the package to npm whenever a release is published. 

Workflow addition:

* [`.github/workflows/publish-to-npm.yaml`](diffhunk://#diff-ba8d164be0b8439ec65972dd4bb482cd3f161af8113995eb0ca17131c73fc745R1-R21): Introduced a new workflow named "Publish Package to npmjs" that triggers on release events of type `published`. It sets up the environment using `actions/checkout` and `actions/setup-node`, installs dependencies with `npm ci`, and publishes the package to npm with provenance and public access, using the `NODE_AUTH_TOKEN` secret for authentication.