### PR TITLE
Update README.md with deploy instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,24 @@ The project has the following files and directories:
 - `dist`: Directory containing generated files. The contents of this directory is published
 - `.github/workflows/ci.yml`: GitHub action that runs typechecks, tests and build
 
-## Next steps
+## Publish to NPM via github action
+Create an account on https://www.npmjs.com/
+create a token
 
-1. Implement your library within `src`. Add tests if you take pride in being a developer
-2. Modify `package.json` – update `name`, `version`, `author` and any other relevant fields
-3. Update `README.md`
-4. `npm publish`. You will have to login to npm if you aren't already logged in
-5. Profit!
+On npm go to settings -> secret and variables -> actions -> new repository secret
+then add your npm secret under the key NODE_AUTH_TOKEN
+
+then in your package.json add
+```json
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/<github org or username>/<repo name>.git"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+```
 
 ## Commands
 


### PR DESCRIPTION
This pull request updates the `README.md` file to provide detailed instructions for publishing the project to NPM via a GitHub Action. It replaces the previous "Next steps" section with a step-by-step guide for setting up NPM secrets and modifying the `package.json` file for publishing.

### Updates to publishing instructions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R50): Replaced the "Next steps" section with a new guide for publishing to NPM using a GitHub Action. The guide includes steps for creating an NPM account, adding an NPM token as a GitHub repository secret, and updating the `package.json` file with `repository` and `publishConfig` fields.